### PR TITLE
Possible Fix For Broken Global ID Queries

### DIFF
--- a/src/unwrangle/support/query_studies.gql
+++ b/src/unwrangle/support/query_studies.gql
@@ -10,42 +10,12 @@ query ($first: Int, $after: ID) {
             description
             email
             website
-            fhirServers {
-              edges {
-                node {
-                  id
-                  name
-                }
-              }
-            }
             studies(first: $first, after: $after) {
               edges {
                 node {
                   id
                   globalId
                   name
-                  studyFhirServers {
-                    edges {
-                      node {
-                        id
-                        ... on StudyFhirServer {
-                          fhirServer {
-                            id
-                            name
-                            url
-                            type
-                            authType
-                            authConfig {
-                              ... on FhirServerAuthConfigOIDCClientCredential {
-                                issuerBaseUrl
-                                clientId
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
                 }
               }
             }

--- a/src/unwrangle/support/query_studies_by_org.gql
+++ b/src/unwrangle/support/query_studies_by_org.gql
@@ -16,28 +16,6 @@ query orgStudies($id: ID!, $first: Int, $after: ID) {
             id
             globalId
             name
-            studyFhirServers {
-              edges {
-                node {
-                  id
-                  ... on StudyFhirServer {
-                    fhirServer {
-                      id
-                      name
-                      url
-                      type
-                      authType
-                      authConfig {
-                        ... on FhirServerAuthConfigOIDCClientCredential {
-                          issuerBaseUrl
-                          clientId
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }


### PR DESCRIPTION
It looks like the dewrangle API queries for studies has changed and the query we had been using no longer worked. I have dropped old references to the fhir servers from the queries, which seems to have fixed the issue. 